### PR TITLE
Fix warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn main() {
         exit(1);
     }
 
-    let mut backend = Arc::new(Mutex::new(
+    let backend = Arc::new(Mutex::new(
         backend::RoundRobinBackend::new(servers).unwrap()
     ));
 

--- a/src/simplelogger.rs
+++ b/src/simplelogger.rs
@@ -1,11 +1,11 @@
 extern crate log;
 
-use log::{LogRecord, LogLevel, LogMetadata, SetLoggerError, LogLevelFilter};
+use log::{LogRecord, LogMetadata, SetLoggerError, LogLevelFilter};
 
 struct SimpleLogger;
 
 impl log::Log for SimpleLogger {
-    fn enabled(&self, metadata: &LogMetadata) -> bool {
+    fn enabled(&self, _metadata: &LogMetadata) -> bool {
         // Todo: implement this or use an existing library
         true
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -11,7 +11,7 @@ pub fn create_sync_thread(backend: Arc<Mutex<RoundRobinBackend>>,
         let pubsub = subscribe_to_redis(&redis_url).unwrap();
         loop {
             let msg = pubsub.get_message().unwrap();
-            handle_message(backend.clone(), msg);
+            handle_message(backend.clone(), msg).unwrap();
         }
     });
 }


### PR DESCRIPTION
- Use unwrap to not silently ignore errors
- Follow conventions with constants
- remove unused imports
- Remove unused mutability
